### PR TITLE
docs: removed unnecessary information from default read me

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,4 +23,4 @@ To learn more about Next.js, take a look at the following resources:
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+You can also check out [the Next.js GitHub repository](https://github.com/vercel/next.js).


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->
## Related issue 

This PR closes #24.

A small clean up of the default read me for next, f.e removing the port since we will be using another. 

## Type of change
- [x] Other (documentation)

## List of changes made
Removed portnumber, vercel deployment information.