### PR TITLE
fix: Add ability to set "CSRF_TRUSTED_ORIGINS" via environment

### DIFF
--- a/backend/bird_ringing/settings.py
+++ b/backend/bird_ringing/settings.py
@@ -35,7 +35,7 @@ DEBUG = strtobool(getenv("DJANGO_DEBUG_MODE", False))
 # Get the list of allowed hosts from the DJANGO_ALLOWED_HOSTS
 # environment variable, or use a default list if not set.  These are
 # domain names or IP addresses that the Django application can serve.
-# We typically need two entries here: "backend", and the publically
+# We typically need two entries here: "backend", and the publicly
 # accessible domain name of the hosting server.
 ALLOWED_HOSTS = parse_csv_from_env("DJANGO_ALLOWED_HOSTS", ["backend", "localhost"])
 
@@ -43,7 +43,7 @@ ALLOWED_HOSTS = parse_csv_from_env("DJANGO_ALLOWED_HOSTS", ["backend", "localhos
 # DJANGO_CSRF_TRUSTED_ORIGINS environment variable, or use an empty list
 # if not set.  These are the origins that are allowed to make cross-site
 # requests to the Django application.  We typically need to include the
-# publically accessible URL of the hosting server here, including the
+# publicly accessible URL of the hosting server here, including the
 # scheme (e.g. "https://").  For example, "https://example.edu".
 CSRF_TRUSTED_ORIGINS = parse_csv_from_env("DJANGO_CSRF_TRUSTED_ORIGINS", [])
 


### PR DESCRIPTION
Add ability to set `CSRF_TRUSTED_ORIGINS` via the environment (uses the environment variable `DJANGO_CSRF_TRUSTED_ORIGINS`), and also add documentation in the `settings.py` file for both `CSRF_TRUSTED_ORIGINS` and `ALLOWED_HOSTS`.

This change makes the Django admin login panel work without returning "Forbidden (403)" and "CSRF verification failed. Request aborted."

This was tested in a separate setup on our developer's machine.  Setting `DJANGO_CSRF_TRUSTED_ORIGINS` to the hosting URL made the admin login work. Setting it to something else, or leaving it unset, caused the admin login to break (as before).

---

Co-pilot summary:

This pull request updates the Django settings to improve host and CSRF security configuration. The changes clarify how allowed hosts and trusted origins are set, making it easier to configure the application for deployment.

Security configuration improvements:

* Updated the default value for `ALLOWED_HOSTS` to include both `"backend"` and `"localhost"`, ensuring development and deployment environments are covered. Added explanatory comments to clarify usage.
* Added `CSRF_TRUSTED_ORIGINS` to allow configuration of trusted origins for CSRF protection via an environment variable, with documentation on proper usage.