### PR TITLE
Make information directly available to the user -remove tooltips

### DIFF
--- a/frontend/src/components/LicensePermissionItem.tsx
+++ b/frontend/src/components/LicensePermissionItem.tsx
@@ -84,7 +84,7 @@ export function LicensePermissionItem({
                 <div key={i}>
                   <p className="my-1 fst-italic">&bull; {p.name}</p>
 
-                  {p.description && <p className="my-1">{p.description}</p>}
+                  {p.description && <p className="mb-3">{p.description}</p>}
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Related issue

This PR closes #102 

NRM doesn't want permission information hidden behind icons in the license entry view.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## List of changes made

- Added the information directly in the view
- Removed the icons

## Screenshot of the fix

<img width="1140" height="839" alt="Screenshot from 2026-02-18 14-36-34" src="https://github.com/user-attachments/assets/69ed5679-d33c-4d04-9a16-2e4b51f90e0c" />

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any
- [x] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue:
