### PR TITLE
fix: make sure that modals are properly closed for users with prefers-reduced-motion

### DIFF
--- a/frontend/src/components/ModalView.tsx
+++ b/frontend/src/components/ModalView.tsx
@@ -21,9 +21,14 @@ export function ModalView() {
     (action?: () => void) => {
       action = action ? action : modal && modal.closeAction;
       const currentRef = modalRef.current;
+      const prefersReducedMotion = matchMedia(
+        "(prefers-reduced-motion: reduce)",
+      ).matches;
       if (currentRef) {
         const handleStack = () => {
-          currentRef.removeEventListener("transitionend", handleStack);
+          if (!prefersReducedMotion) {
+            currentRef.removeEventListener("transitionend", handleStack);
+          }
           if (modal) {
             if (action) {
               action();
@@ -32,7 +37,11 @@ export function ModalView() {
           }
         };
         setIsOpen(false);
-        currentRef.addEventListener("transitionend", handleStack);
+        if (prefersReducedMotion) {
+          handleStack();
+        } else {
+          currentRef.addEventListener("transitionend", handleStack);
+        }
       }
     },
     [modal, modals, setIsOpen, modalRef],


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->
## Related issue(s) and PR(s)

This PR closes #132

It will make the modal close properly when users have `prefers-reduced-motion: reduce`

## Type of change

<!-- Please delete options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)


## List of changes made 

- Add a check for  `prefers-reduced-motion: reduce` and ignore the modal transition if that is the case

## Testing

Enable prefers reduced motion setting in Firefox:
- go to: `about:config`
- add configuration variable `ui.prefersReducedMotion` as an integer and set it to `1`

General:
- go to http://localhost:3210/system/welcome
- press any of the buttons to open a dialog
- close the dialog
- expect no animation when closing the dialog
- expect to be able to continue using the site as usual

## Further comments

<!-- Specify questions or related information -->

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any
- [x] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue:
- [ ] **Code Review Completed:**
  - The code has been reviewed by at least one team member other than its author (adhering to the four-eyes principle).
  - Considerations: PR reviews, presentations to co-workers, pair/mob programming sessions.
  
- [ ] **Documentation Updated (if applicable):**
  - Relevant documentation is current.
  - Considerations: in-code comments, generated documentation, README files, Swagger docs, Postman collections, Confluence pages, etc.
  
- [ ] **Follow-up Backlog Items Created (if applicable):**
  - Necessary follow-up tasks have been identified and added to the backlog.
  - Considerations: next iteration tasks, performance enhancements, visual improvements, refactoring needs, addressing technical debt.
