### PR TITLE
Change signout-OK-green

### DIFF
--- a/frontend/src/components/SignOutModal.tsx
+++ b/frontend/src/components/SignOutModal.tsx
@@ -43,7 +43,7 @@ export function useSignOutAction() {
         {
           label: t("okModal"),
           action: closeAction,
-          type: "success",
+          type: "primary",
         },
       ],
     });


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->
## Related issue(s) and PR(s)

This PR doesn't have a connected issue.

I noticed that the confirm dialogue after signing out has a button with type "success" that comes with a bright green color.
Even though I think that "success" makes sense semantically, it's the only place in the system (as far as I know) where that green would appear, and it bothers me... All other modals have "Ok"-buttons with type "primary" that comes with the dark forest green.
It would make me very happy if this button could align with the others.

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## List of changes made

- changed a single button type from "success" to "primary"
<img width="720" height="405" alt="image" src="https://github.com/user-attachments/assets/101885de-f262-47a3-93dd-ed823fa8171f" />

<!-- Attach screenshot if relevant -->

## Testing

Sign in, sign out and see the green.

