### PR TITLE
fix: allow ringer names to wrap in license view

### DIFF
--- a/frontend/src/components/LicenceView.tsx
+++ b/frontend/src/components/LicenceView.tsx
@@ -221,7 +221,7 @@ export function LicenceView({ license, mnr }: LicenceViewProps) {
                   <div className="col-12 col-md-2 fw-semibold text-capitalize">
                     {doc.type}
                   </div>
-                  <div className="col-12 col-md-3 text-nowrap">
+                  <div className="col-12 col-md-3">
                     <i className="bi bi-person text-primary me-1" />
                     <Link href={`/actors/entry?entryId=${doc.actor_id}`}>
                       {doc.actor}
@@ -265,7 +265,7 @@ export function LicenceView({ license, mnr }: LicenceViewProps) {
                   <div className="col-12 col-md-2 fw-semibold text-capitalize">
                     {item.type}
                   </div>
-                  <div className="col-12 col-md-3 text-nowrap">
+                  <div className="col-12 col-md-3">
                     <i className="bi bi-person text-primary me-1" />
                     <Link href={`/actors/entry?entryId=${item.actor_id}`}>
                       {item.actor}


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR closes #186.

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## List of changes made

* Removed `text-nowrap` from the Documents and Communication sections in `LicenceView.tsx` so long ringer names no longer overlap adjacent content.

## Screenshot of the fix

<img width="980" height="465" alt="image" src="https://github.com/user-attachments/assets/aa7bf735-b358-44cc-adcc-305aec7e5622" />

## Testing

- Open a license with long ringer names (e.g. a station) and verify the Documents and Communication sections render without overlap.

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any
- [x] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue:
- [ ] **Code Review Completed:**
  - The code has been reviewed by at least one team member other than its author (adhering to the four-eyes principle).
  - Considerations: PR reviews, presentations to co-workers, pair/mob programming sessions.
  
- [ ] **Documentation Updated (if applicable):**
  - Relevant documentation is current.
  - Considerations: in-code comments, generated documentation, README files, Swagger docs, Postman collections, Confluence pages, etc.
  
- [ ] **Follow-up Backlog Items Created (if applicable):**
  - Necessary follow-up tasks have been identified and added to the backlog.
  - Considerations: next iteration tasks, performance enhancements, visual improvements, refactoring needs, addressing technical debt.
