### PR TITLE
fix: Add ca-certificates package and run update-ca-certificates

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -8,6 +8,7 @@ ARG GID=${BUILD_ID#*:}
 RUN --mount=type=cache,id=apk-cache,target=/var/cache/apk \
     apk --cache-dir=/var/cache/apk add \
 	build-base \
+	ca-certificates \
 	ccache \
 	dumb-init \
 	libpq \
@@ -15,6 +16,8 @@ RUN --mount=type=cache,id=apk-cache,target=/var/cache/apk \
 	cairo \
 	fontconfig \
 	font-noto
+
+RUN update-ca-certificates
 RUN fc-cache -f
 
 ENV HOME=/app


### PR DESCRIPTION
<!-- Remove sections from this template that are not used -->
## Related issue(s) and PR(s)

This PR closes #201 

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change

<!-- Please delete options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## List of changes made

- Add `ca-certificates` package to `backend` container.
- Run `update-ca-certificates` while building.

---

Co-pilot summary:

This pull request makes a minor update to the backend Dockerfile by ensuring that CA certificates are installed and updated in the build environment. This improves the container's ability to make secure HTTPS connections.

- Dockerfile improvements:
  * Added the `ca-certificates` package to the list of installed packages and ran `update-ca-certificates` to ensure up-to-date trusted root certificates.