### PR TITLE
fix: Don't build container images when merging to "main"

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - main
     tags:
       - 'v*'
 


### PR DESCRIPTION
Only build when merging to "develop" and when tagging.  Note that the "latest" tag will still be applied to the builds that corresponds to the "main" branch, which will be the case when tagging.

<!-- Remove sections from this template that are not used -->
## Related issue(s) and PR(s)

This PR closes #207 

<!-- Include below a description of the changes proposed in the pull request -->

## Type of change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## List of changes made

A single-line change, removing `main` from the workflow triggers.

