### PR TITLE
feat: adding mailpit to dev compose file for issue #230

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ mkdir -p backend/mock_data/example/
 ./data-init
 ```
 
+### Local email testing
+
+For local development, the Docker Compose setup includes Mailpit for capturing
+outgoing emails. Open the Mailpit at `http://localhost:8025/` to inspect emails sent by the
+application without sending real messages.
+
 ## Frontend development
 
 ### Adding dependencies

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,13 +35,13 @@ services:
       POSTGRES_PASSWORD_FILE: /run/secrets/db-admin-pass
       #DJANGO_EMAIL_BACKEND: django.core.mail.backends.console.EmailBackend
       DJANGO_EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
-      DJANGO_DEFAULT_FROM_EMAIL: licensing-local@example.test
+      DJANGO_DEFAULT_FROM_EMAIL: licensing-local@example.com
       DJANGO_EMAIL_HOST: mailpit
       DJANGO_EMAIL_PORT: 1025
       DJANGO_EMAIL_HOST_USER: ""
       DJANGO_EMAIL_USE_SSL: false
       DJANGO_EMAIL_HOST_PASSWORD_FILE: /run/secrets/django-email-password
-      LICENSING_EMAIL_FROM_ADDR: <address used in from field for licensing emails>
+      LICENSING_EMAIL_FROM_ADDR: user@email.example.com
       LICENSING_EMAIL_SUBJECT: "Hello world from bird ringing ({{mnr}}) {{name|safe}}"
     volumes:
       - ./backend:/app

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,6 +11,12 @@ services:
       retries: 5
       start_period: 10s
 
+  mailpit:
+    image: axllent/mailpit
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+
   backend-init:
     build:
       target: dev
@@ -27,13 +33,13 @@ services:
       SERVICE_MODE: development
       DJANGO_DEBUG_MODE: True
       POSTGRES_PASSWORD_FILE: /run/secrets/db-admin-pass
-      DJANGO_DEFAULT_FROM_EMAIL: <address used in from field>
-      DJANGO_EMAIL_BACKEND: django.core.mail.backends.console.EmailBackend
-      #DJANGO_EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
-      DJANGO_EMAIL_HOST: <smtp host>
-      DJANGO_EMAIL_PORT: <smtp port>
-      DJANGO_EMAIL_HOST_USER: <smtp user>
-      DJANGO_EMAIL_USE_SSL: False
+      #DJANGO_EMAIL_BACKEND: django.core.mail.backends.console.EmailBackend
+      DJANGO_EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
+      DJANGO_DEFAULT_FROM_EMAIL: licensing-local@example.test
+      DJANGO_EMAIL_HOST: mailpit
+      DJANGO_EMAIL_PORT: 1025
+      DJANGO_EMAIL_HOST_USER: ""
+      DJANGO_EMAIL_USE_SSL: false
       DJANGO_EMAIL_HOST_PASSWORD_FILE: /run/secrets/django-email-password
       LICENSING_EMAIL_FROM_ADDR: <address used in from field for licensing emails>
       LICENSING_EMAIL_SUBJECT: "Hello world from bird ringing ({{mnr}}) {{name|safe}}"


### PR DESCRIPTION
## Related issue(s) and PR(s)

This PR closes #230 

Adding Mailpit to the docker compose for dev

## Type of change

- [x] Other (for development perposes)

## List of changes made

- Added the mailpit configuration in the compose for development
- Added a small instruction in the Read me

## Screenshots
<img width="1835" height="881" alt="image" src="https://github.com/user-attachments/assets/b6b61feb-3150-436f-b34f-94c36430c3c0" />


## Testing

Uncomment the following from your docker-compose override file, if you have one:
```
# DJANGO_EMAIL_BACKEND
# DJANGO_EMAIL_HOST_USER
# DJANGO_EMAIL_HOST
# DJANGO_EMAIL_PORT
# DJANGO_EMAIL_USE_SSL
```

And then start then application and visit http://localhost:8025/. Send an email from the application and see it in the mailpit at http://localhost:8025/

## Definition of Done checklist

- [x] I have made an effort making the commit history understandable
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Existing tests are passing and I wrote unit tests for new functionality
- [x] My changes generate no new warnings
- [x] Make sure the layout and text follow design sketches, if there are any
- [x] All Acceptance Criteria (AC) Fulfilled and checked in the Related issue:
- [x] **Documentation Updated (if applicable):**
  - Relevant documentation is current.
  - Considerations: in-code comments, generated documentation, README files, Swagger docs, Postman collections, Confluence pages, etc.

